### PR TITLE
fix: should bind ctx to egg router controller this context

### DIFF
--- a/test/EggRouter.test.ts
+++ b/test/EggRouter.test.ts
@@ -1,8 +1,27 @@
 import { strict as assert } from 'node:assert';
 import is from 'is-type-of';
+import Koa from '@eggjs/koa';
+import request from 'supertest';
 import { EggRouter } from '../src/index.js';
 
 describe('test/EggRouter.test.ts', () => {
+  it('auto bind ctx to this on controller', async () => {
+    const app = new Koa();
+    const router = new EggRouter({}, app as any);
+    router.get('home', '/', function(this: any) {
+      this.body = {
+        url: this.router.url('home'),
+        method: this.method,
+      };
+    });
+    app.use(router.routes());
+    const res = await request(app.callback())
+      .get('/')
+      .expect(200);
+    assert.equal(res.body.url, '/');
+    assert.equal(res.body.method, 'GET');
+  });
+
   it('creates new router with egg app', () => {
     const app = { controller: {} };
     const router = new EggRouter({}, app);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the middleware registration process by ensuring generator functions are properly checked and handled.

- **New Features**
  - Automatic context (`ctx`) binding to `this` within controller functions in the `EggRouter` class.

- **Tests**
  - Added a new test case to verify the automatic context binding feature within the `EggRouter` class.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->