### PR TITLE
feat: remove is-type-of and debug deps

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -1,4 +1,4 @@
-name: CI
+name: CI for 2.x
 
 on:
   push:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Release
+name: Release for 2.x
 
 on:
   push:

--- a/lib/egg_router.js
+++ b/lib/egg_router.js
@@ -1,11 +1,10 @@
 'use strict';
 
-const is = require('is-type-of');
-const Router = require('./router');
 const utility = require('utility');
 const inflection = require('inflection');
 const assert = require('assert');
 const utils = require('./utils');
+const Router = require('./router');
 
 const METHODS = [ 'head', 'options', 'get', 'put', 'patch', 'post', 'delete' ];
 
@@ -138,6 +137,7 @@ class EggRouter extends Router {
    * @return {Router} return route object.
    * @since 1.0.0
    */
+
   resources(...args) {
     const splited = spliteAndResolveRouterParams({ args, app: this.app });
     const middlewares = splited.middlewares;
@@ -198,7 +198,7 @@ class EggRouter extends Router {
     const args = params;
     let url = route.path;
 
-    assert(!is.regExp(url), `Can't get the url for regExp ${url} for by name '${name}'`);
+    assert(!(url instanceof RegExp), `Can't get the url for regExp ${url} for by name '${name}'`);
 
     const queries = [];
     if (typeof args === 'object' && args !== null) {
@@ -263,7 +263,7 @@ class EggRouter extends Router {
 function spliteAndResolveRouterParams({ args, app }) {
   let prefix;
   let middlewares;
-  if (args.length >= 3 && (is.string(args[1]) || is.regExp(args[1]))) {
+  if (args.length >= 3 && (typeof args[1] === 'string' || args[1] instanceof RegExp)) {
     // app.get(name, url, [...middleware], controller)
     prefix = args.slice(0, 2);
     middlewares = args.slice(2);
@@ -285,7 +285,7 @@ function spliteAndResolveRouterParams({ args, app }) {
  * @return {Function} controller function
  */
 function resolveController(controller, app) {
-  if (is.string(controller)) {
+  if (typeof controller === 'string') {
     const actions = controller.split('.');
     let obj = app.controller;
     actions.forEach(key => {

--- a/lib/layer.js
+++ b/lib/layer.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const debug = require('debug')('egg-router:layer');
+const debug = require('util').debuglog('egg-router:layer');
 const pathToRegExp = require('path-to-regexp');
 const uri = require('urijs');
 const utility = require('utility');

--- a/lib/router.js
+++ b/lib/router.js
@@ -4,7 +4,7 @@
  * RESTful resource routing middleware for eggjs.
  */
 
-const debug = require('debug')('egg-router');
+const debug = require('util').debuglog('egg-router');
 const compose = require('koa-compose');
 const HttpError = require('http-errors');
 const methods = require('methods');

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,18 +1,34 @@
 'use strict';
 
 const convert = require('koa-convert');
-const is = require('is-type-of');
 const co = require('co');
+
+function isGeneratorFunction(obj) {
+  return obj
+    && obj.constructor
+    && obj.constructor.name === 'GeneratorFunction';
+}
 
 module.exports = {
   async callFn(fn, args, ctx) {
     args = args || [];
-    if (!is.function(fn)) return;
-    if (is.generatorFunction(fn)) fn = co.wrap(fn);
+    if (typeof fn !== 'function') return;
+    if (isGeneratorFunction(fn)) fn = co.wrap(fn);
     return ctx ? fn.call(ctx, ...args) : fn(...args);
   },
 
   middleware(fn) {
-    return is.generatorFunction(fn) ? convert(fn) : fn;
+    return isGeneratorFunction(fn) ? convert(fn) : fn;
+  },
+
+  isGeneratorFunction,
+  isAsyncFunction(obj) {
+    return obj
+      && obj.constructor
+      && obj.constructor.name === 'AsyncFunction';
+  },
+  isPromise(obj) {
+    return obj
+      && typeof obj.then === 'function';
   },
 };

--- a/package.json
+++ b/package.json
@@ -29,14 +29,12 @@
   ],
   "dependencies": {
     "co": "^4.6.0",
-    "debug": "^3.1.0",
     "http-errors": "^1.3.1",
     "inflection": "^1.12.0",
-    "is-type-of": "^1.2.1",
     "koa-compose": "^3.0.0",
     "koa-convert": "^1.2.0",
     "methods": "^1.0.1",
-    "path-to-regexp": "^1.1.1",
+    "path-to-regexp": "^1.9.0",
     "urijs": "^1.19.0",
     "utility": "^1.15.0"
   },

--- a/test/lib/egg_router.test.js
+++ b/test/lib/egg_router.test.js
@@ -2,7 +2,7 @@
 
 const EggRouter = require('../../').EggRouter;
 const assert = require('assert');
-const is = require('is-type-of');
+const { isGeneratorFunction, isAsyncFunction } = require('../../lib/utils');
 
 describe('test/lib/egg_router.test.js', () => {
   it('creates new router with egg app', function() {
@@ -126,16 +126,16 @@ describe('test/lib/egg_router.test.js', () => {
     assert(router.stack[0].path === '/foo');
     assert.deepEqual(router.stack[0].methods, [ 'HEAD', 'GET' ]);
     assert(router.stack[0].stack.length === 4);
-    assert(!is.generatorFunction(router.stack[0].stack[0]));
-    assert(is.asyncFunction(router.stack[0].stack[1]));
-    assert(!is.generatorFunction(router.stack[0].stack[3]));
+    assert(!isGeneratorFunction(router.stack[0].stack[0]));
+    assert(isAsyncFunction(router.stack[0].stack[1]));
+    assert(!isGeneratorFunction(router.stack[0].stack[3]));
     assert(router.stack[1].name === 'hello');
     assert(router.stack[1].path === '/hello/world');
     assert.deepEqual(router.stack[1].methods, [ 'POST' ]);
     assert(router.stack[1].stack.length === 4);
-    assert(!is.generatorFunction(router.stack[1].stack[0]));
-    assert(is.asyncFunction(router.stack[1].stack[1]));
-    assert(!is.generatorFunction(router.stack[1].stack[3]));
+    assert(!isGeneratorFunction(router.stack[1].stack[0]));
+    assert(isAsyncFunction(router.stack[1].stack[1]));
+    assert(!isGeneratorFunction(router.stack[1].stack[3]));
   });
 
   it('should app.resource() work', () => {

--- a/test/lib/utils.test.js
+++ b/test/lib/utils.test.js
@@ -1,14 +1,13 @@
 'use strict';
 
-const utils = require('../../lib/utils');
-const is = require('is-type-of');
 const assert = require('assert');
+const utils = require('../../lib/utils');
 
 describe('test/lib/utils.test.js', () => {
   describe('callFn', () => {
     it('should not function return same', () => {
       const res = utils.callFn('foo');
-      assert(is.promise(res));
+      assert(utils.isPromise(res));
       return res.then(result => assert(result === undefined));
     });
 
@@ -16,7 +15,7 @@ describe('test/lib/utils.test.js', () => {
       const res = utils.callFn(async (foo, bar) => {
         return foo + bar;
       }, [ 1, 2 ]);
-      assert(is.promise(res));
+      assert(utils.isPromise(res));
       return res.then(result => assert(result === 3));
     });
 
@@ -24,7 +23,7 @@ describe('test/lib/utils.test.js', () => {
       const res = utils.callFn(function* (foo, bar) {
         return foo + bar;
       }, [ 1, 2 ]);
-      assert(is.promise(res));
+      assert(utils.isPromise(res));
       return res.then(result => assert(result === 3));
     });
 
@@ -32,7 +31,7 @@ describe('test/lib/utils.test.js', () => {
       const res = utils.callFn((foo, bar) => {
         return foo + bar;
       }, [ 1, 2 ]);
-      assert(is.promise(res));
+      assert(utils.isPromise(res));
       return res.then(result => assert(result === 3));
     });
 
@@ -40,7 +39,7 @@ describe('test/lib/utils.test.js', () => {
       const res = utils.callFn(async function(bar) {
         return this.foo + bar;
       }, [ 2 ], { foo: 1 });
-      assert(is.promise(res));
+      assert(utils.isPromise(res));
       return res.then(result => assert(result === 3));
     });
   });
@@ -48,14 +47,14 @@ describe('test/lib/utils.test.js', () => {
   describe('middleware', () => {
     it('should work with async function', () => {
       const res = utils.middleware(async () => {});
-      assert(is.asyncFunction(res));
+      assert(utils.isAsyncFunction(res));
     });
 
     it('should work with generator function', () => {
       const res = utils.middleware(function* () {
         return;
       });
-      assert(!is.generatorFunction(res));
+      assert(!utils.isGeneratorFunction(res));
     });
   });
 });


### PR DESCRIPTION
force path-to-regexp to >=1.9.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Added `resources` method to router for enhanced RESTful routing capabilities
  - Introduced new utility functions for function type checking

- **Dependency Updates**
  - Updated `path-to-regexp` dependency
  - Removed `debug` and `is-type-of` dependencies

- **Performance Improvements**
  - Replaced external debugging library with Node.js native `util.debuglog`
  - Streamlined type checking with native JavaScript methods

- **Maintenance**
  - Refactored type checking across multiple files
  - Updated GitHub Actions workflows for 2.x branch

<!-- end of auto-generated comment: release notes by coderabbit.ai -->